### PR TITLE
1.0.7, added videoTag check for audio-only player

### DIFF
--- a/Player.vue
+++ b/Player.vue
@@ -147,7 +147,7 @@
         this.loadMedia()
       },
       setDisablePictureInPicture () {
-        if (this.disablePictureInPicture) {
+        if (this.disablePictureInPicture && document.body.contains(this.$refs.videoTag)) {
           this.$refs.videoTag.setAttribute('disablePictureInPicture', '');
         }
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kaliop-media-player",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Kaliop customizable media player for handling audio/video playlist",
   "main": "kaliopMediaPlayerHandler.js",
   "scripts": {


### PR DESCRIPTION
fixed error when kaliop-media-player was used in audio-only context.
